### PR TITLE
Fix detection of cache value type

### DIFF
--- a/src/localStorage.ts
+++ b/src/localStorage.ts
@@ -26,7 +26,7 @@ const localStorageV2: LocalStorage = {
 
         const returnValue = values[key];
 
-        resolve(returnValue === 'string' ? returnValue : undefined);
+        resolve(typeof returnValue === 'string' ? returnValue : undefined);
       })
     ),
   set: (key, value) =>


### PR DESCRIPTION
## Description

Return value is a stringified JSON object. `typeof` missing in checking validity of its stored value.